### PR TITLE
Search from polygons instead of just from single points

### DIFF
--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
@@ -138,13 +138,13 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
             queueByWeighting.add(currentLabel);
             if (traversalMode == TraversalMode.NODE_BASED) {
                 fromMap.put(node, currentLabel);
+                consumer.accept(currentLabel);
             }
         }
         while (!finished()) {
             IsoLabel currentLabel = queueByWeighting.poll();
             if (currentLabel.deleted)
                 continue;
-            consumer.accept(currentLabel);
             currentLabel.deleted = true;
             visitedNodes++;
 
@@ -162,15 +162,17 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
                 long nextTime = GHUtility.calcMillisWithTurnMillis(weighting, iter, reverseFlow, currentLabel.edge) + currentLabel.time;
                 int nextTraversalId = traversalMode.createTraversalId(iter, reverseFlow);
                 IsoLabel label = fromMap.get(nextTraversalId);
+                IsoLabel newLabel = new IsoLabel(iter.getAdjNode(), iter.getEdge(), nextWeight, nextTime, nextDistance, currentLabel);
+                consumer.accept(newLabel);
                 if (label == null) {
-                    label = new IsoLabel(iter.getAdjNode(), iter.getEdge(), nextWeight, nextTime, nextDistance, currentLabel);
+                    label = newLabel;
                     fromMap.put(nextTraversalId, label);
                     if (getExploreValue(label) <= limit) {
                         queueByWeighting.add(label);
                     }
                 } else if (label.weight > nextWeight) {
                     label.deleted = true;
-                    label = new IsoLabel(iter.getAdjNode(), iter.getEdge(), nextWeight, nextTime, nextDistance, currentLabel);
+                    label = newLabel;
                     fromMap.put(nextTraversalId, label);
                     if (getExploreValue(label) <= limit) {
                         queueByWeighting.add(label);

--- a/core/src/main/java/com/graphhopper/storage/index/Snap.java
+++ b/core/src/main/java/com/graphhopper/storage/index/Snap.java
@@ -124,6 +124,10 @@ public class Snap {
         return snappedPoint;
     }
 
+    public void setSnappedPoint(GHPoint3D point) {
+        snappedPoint = point;
+    }
+
     /**
      * Calculates the closest point on the edge from the query point.
      */

--- a/web-api/src/main/java/com/graphhopper/IsochroneRequest.java
+++ b/web-api/src/main/java/com/graphhopper/IsochroneRequest.java
@@ -3,25 +3,23 @@ package com.graphhopper;
 import java.util.ArrayList;
 import java.util.List;
 
-import com.graphhopper.util.shapes.GHPoint;
-
 public class IsochroneRequest {
-    private List<GHPoint> points = new ArrayList<GHPoint>();
+    private List<Region> regions = new ArrayList<Region>();
     private String profileName = "";
     private long timeLimitInSeconds = -1;
     private long distanceLimitInMeters = -1;
 
-    public IsochroneRequest setPoints(List<GHPoint> points) {
-        this.points = points;
+    public IsochroneRequest setRegions(List<Region> regions) {
+        this.regions = regions;
         return this;
     }
 
-    public List<GHPoint> getPoints() {
-        return points;
+    public List<Region> getRegions() {
+        return regions;
     }
 
-    public void addPoint(GHPoint point) {
-        this.points.add(point);
+    public void addRegion(Region region) {
+        this.regions.add(region);
     }
 
     public IsochroneRequest setProfileName(String profileName) {

--- a/web-api/src/main/java/com/graphhopper/Region.java
+++ b/web-api/src/main/java/com/graphhopper/Region.java
@@ -1,0 +1,24 @@
+package com.graphhopper;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.GHPoint;
+
+public class Region {
+    private List<GHPoint> points = new ArrayList<GHPoint>();
+
+    public Region setPoints(List<GHPoint> points) {
+        this.points = points;
+        return this;
+    }
+
+    public List<GHPoint> getPoints() {
+        return points;
+    }
+
+    public void addPoint(GHPoint point) {
+        this.points.add(point);
+    }
+}

--- a/web-api/src/main/java/com/graphhopper/jackson/IsochroneRequestDeserializer.java
+++ b/web-api/src/main/java/com/graphhopper/jackson/IsochroneRequestDeserializer.java
@@ -6,12 +6,14 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.graphhopper.util.shapes.GHPoint;
 import com.graphhopper.IsochroneRequest;
+import com.graphhopper.Region;
 
 import java.io.IOException;
 
 class IsochroneRequestDeserializer extends JsonDeserializer<IsochroneRequest> {
     @Override
-    public IsochroneRequest deserialize(JsonParser jsonParser, DeserializationContext deserializationContext) throws IOException {
+    public IsochroneRequest deserialize(JsonParser jsonParser, DeserializationContext deserializationContext)
+            throws IOException {
         IsochroneRequest request = new IsochroneRequest();
         JsonNode treeNode = jsonParser.readValueAsTree();
         request.setProfileName(treeNode.get("profileName").asText());
@@ -21,9 +23,14 @@ class IsochroneRequestDeserializer extends JsonDeserializer<IsochroneRequest> {
         if (treeNode.has("distanceLimitInMeters")) {
             request.setDistanceLimitInMeters(treeNode.get("distanceLimitInMeters").asLong());
         }
-        for (JsonNode node : treeNode.get("points")) {
-            GHPoint point = new GHPoint(node.get("latitude").asDouble(), node.get("longitude").asDouble());
-            request.addPoint(point);
+        for (JsonNode polygonNode : treeNode.get("polygons")) {
+            JsonNode regionNode = polygonNode.get("points");
+            Region region = new Region();
+            for (JsonNode pointNode : regionNode) {
+                region.addPoint(
+                        new GHPoint(pointNode.get("latitude").asDouble(), pointNode.get("longitude").asDouble()));
+            }
+            request.addRegion(region);
         }
         return request;
     }

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -2,6 +2,7 @@ package com.graphhopper.resources;
 
 import com.graphhopper.GraphHopper;
 import com.graphhopper.IsochroneRequest;
+import com.graphhopper.Region;
 import com.graphhopper.config.Profile;
 import com.graphhopper.http.ProfileResolver;
 import com.graphhopper.storage.NodeAccess;
@@ -17,7 +18,11 @@ import com.graphhopper.storage.BaseGraph;
 import com.graphhopper.storage.index.LocationIndex;
 import com.graphhopper.storage.index.Snap;
 import com.graphhopper.util.*;
+import com.graphhopper.util.shapes.BBox;
 import com.graphhopper.util.shapes.GHPoint;
+import com.graphhopper.util.shapes.GHPoint3D;
+import com.graphhopper.util.shapes.Polygon;
+
 import org.locationtech.jts.geom.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -80,12 +85,52 @@ public class IsochroneResource {
                 .getBooleanEncodedValue(Subnetwork.key(request.getProfileName()));
         assert (!hintsMap.has(Parameters.Routing.BLOCK_AREA));
         List<Snap> snaps = new ArrayList<Snap>();
-        for (GHPoint point : request.getPoints()) {
-            Snap snap = locationIndex.findClosest(point.lat, point.lon,
-                    new DefaultSnapFilter(weighting, inSubnetworkEnc));
-            if (!snap.isValid())
-                throw new IllegalArgumentException("Point not found:" + point);
-            snaps.add(snap);
+        final NodeAccess nodeAccess = graphHopper.getBaseGraph().getNodeAccess();
+        for (Region region : request.getRegions()) {
+            List<GHPoint> points = region.getPoints();
+            assert (!points.isEmpty());
+            double[] lats = new double[points.size()];
+            double[] lons = new double[points.size()];
+            for (int i = 0; i < points.size(); i += 1) {
+                GHPoint point = points.get(i);
+                lats[i] = point.lat;
+                lons[i] = point.lon;
+
+                GHPoint nextPoint = points.get(i == points.size() - 1 ? 0 : (i+1));
+                int numSubsegments = (int)(Math.ceil((Math.abs(point.lat-nextPoint.lat)+Math.abs(point.lon-nextPoint.lon)) / 1e-4))+1;
+                for (int j = 0; j < numSubsegments; j++) {
+                    double lat = ((point.lat * j) + nextPoint.lat * (numSubsegments - j)) / numSubsegments;
+                    double lon = ((point.lon * j) + nextPoint.lon * (numSubsegments - j)) / numSubsegments;
+                    Snap snap = locationIndex.findClosest(lat, lon,
+                            new DefaultSnapFilter(weighting, inSubnetworkEnc));
+                    if (!snap.isValid())
+                        throw new IllegalArgumentException("Point not found: (" + lat + ", " + lon + ")");
+                    snaps.add(snap);
+                }
+            }
+            if (points.size() > 1) {
+                Polygon polygon = new Polygon(lats, lons);
+                BBox bbox = polygon.getBounds();
+                locationIndex.query(bbox, edgeId -> {
+                    EdgeIteratorState edge = graphHopper.getBaseGraph().getEdgeIteratorStateForKey(edgeId * 2);
+                    for (int i = 0; i < 2; i++) {
+                        int nodeId = i == 0 ? edge.getBaseNode() : edge.getAdjNode();
+                        double lat = nodeAccess.getLat(nodeId);
+                        double lon = nodeAccess.getLon(nodeId);
+                        if (polygon.contains(lat, lon)) {
+                            logger.info("Contained in polygon: (" + lat + ", " + lon + ")");
+                            final Snap snap = new Snap(lat, lon);
+                            snap.setQueryDistance(0);
+                            snap.setClosestNode(nodeId);
+                            snap.setClosestEdge(edge.detach(false));
+                            snap.setSnappedPosition(Snap.Position.TOWER);
+                            snap.setQueryDistance(0);
+                            snap.setSnappedPoint(new GHPoint3D(lat, lon, 0));
+                            snaps.add(snap);
+                        }
+                    }
+                });
+            }
         }
         QueryGraph queryGraph = QueryGraph.create(graph, snaps);
         TraversalMode traversalMode = profile.isTurnCosts() ? EDGE_BASED : NODE_BASED;
@@ -125,13 +170,16 @@ public class IsochroneResource {
             site.z = exploreValue;
             sites.add(site);
 
-            // TODO: Visit all edges, not just tree edges.
             if (label.parent != null) {
                 double parentExploreValue = fz.applyAsDouble(label.parent);
                 EdgeIteratorState edge = queryGraph.getEdgeIteratorState(label.edge, label.node);
                 ArrayList<CoordinateWithCost> coordinates = new ArrayList<>();
                 double c1 = parentExploreValue * normalization_factor;
                 double c2 = exploreValue * normalization_factor;
+                if (na.getLat(label.parent.node) > 63.1788 && na.getLat(label.parent.node) < 63.1812 && na.getLon(label.parent.node) > 14.65493 && na.getLon(label.parent.node) < 14.663) {
+                    logger.info("Edge from: (" + na.getLat(label.parent.node) + ", " + na.getLon(label.parent.node) + ") at time " + c1);
+                    logger.info("Edge to: (" + lat + ", " + lon + ") at time " + c2);
+                }
                 coordinates.add(new CoordinateWithCost(
                         na.getLat(label.parent.node),
                         na.getLon(label.parent.node),
@@ -161,22 +209,6 @@ public class IsochroneResource {
         ResponseWithCosts response = new ResponseWithCosts();
         response.segments = segments;
         return response;
-    }
-
-    private Polygon heuristicallyFindMainConnectedComponent(MultiPolygon multiPolygon, Point point) {
-        int maxPoints = 0;
-        Polygon maxPolygon = null;
-        for (int j = 0; j < multiPolygon.getNumGeometries(); j++) {
-            Polygon polygon = (Polygon) multiPolygon.getGeometryN(j);
-            if (polygon.contains(point)) {
-                return polygon;
-            }
-            if (polygon.getNumPoints() > maxPoints) {
-                maxPoints = polygon.getNumPoints();
-                maxPolygon = polygon;
-            }
-        }
-        return maxPolygon;
     }
 
     /**

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -118,7 +118,6 @@ public class IsochroneResource {
                         double lat = nodeAccess.getLat(nodeId);
                         double lon = nodeAccess.getLon(nodeId);
                         if (polygon.contains(lat, lon)) {
-                            logger.info("Contained in polygon: (" + lat + ", " + lon + ")");
                             final Snap snap = new Snap(lat, lon);
                             snap.setQueryDistance(0);
                             snap.setClosestNode(nodeId);
@@ -176,10 +175,6 @@ public class IsochroneResource {
                 ArrayList<CoordinateWithCost> coordinates = new ArrayList<>();
                 double c1 = parentExploreValue * normalization_factor;
                 double c2 = exploreValue * normalization_factor;
-                if (na.getLat(label.parent.node) > 63.1788 && na.getLat(label.parent.node) < 63.1812 && na.getLon(label.parent.node) > 14.65493 && na.getLon(label.parent.node) < 14.663) {
-                    logger.info("Edge from: (" + na.getLat(label.parent.node) + ", " + na.getLon(label.parent.node) + ") at time " + c1);
-                    logger.info("Edge to: (" + lat + ", " + lon + ") at time " + c2);
-                }
                 coordinates.add(new CoordinateWithCost(
                         na.getLat(label.parent.node),
                         na.getLon(label.parent.node),


### PR DESCRIPTION
* Get search origin as a list of polygons, instead of a list of points.
* Add all nodes inside a polygon as Dijkstra start nodes.
* Snap points along polygon border to the graph and add the snapping points as Dijkstra start nodes.
* Return all edges traversed during Dijkstra, not just edges that are part of the shortest-path tree. This is necessary because even though an edge might not be the optimal way to reach the destination node, it might still be the optimal way to reach some points partway along the edge.