### PR TITLE
Use distance as weight when searching from multiple nodes.

### DIFF
--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
@@ -128,10 +128,10 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
     public void search(int from, final Consumer<IsoLabel> consumer) {
         List<Integer> fromList = new ArrayList<Integer>();
         fromList.add(from);
-        search(fromList, consumer);
+        search(false, fromList, consumer);
     }
 
-    public void search(List<Integer> from, final Consumer<IsoLabel> consumer) {
+    public void search(boolean useDistanceAsWeight, List<Integer> from, final Consumer<IsoLabel> consumer) {
         checkAlreadyRun();
         for (int node : from) {
             IsoLabel currentLabel = new IsoLabel(node, -1, 0, 0, 0, null);
@@ -159,6 +159,9 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
                     continue;
 
                 double nextDistance = iter.getDistance() + currentLabel.distance;
+                if (useDistanceAsWeight) {
+                    nextWeight = nextDistance;
+                }
                 long nextTime = GHUtility.calcMillisWithTurnMillis(weighting, iter, reverseFlow, currentLabel.edge) + currentLabel.time;
                 int nextTraversalId = traversalMode.createTraversalId(iter, reverseFlow);
                 IsoLabel label = fromMap.get(nextTraversalId);

--- a/web-api/src/main/java/com/graphhopper/IsochroneRequest.java
+++ b/web-api/src/main/java/com/graphhopper/IsochroneRequest.java
@@ -8,6 +8,7 @@ public class IsochroneRequest {
     private String profileName = "";
     private long timeLimitInSeconds = -1;
     private long distanceLimitInMeters = -1;
+    private boolean useDistanceAsWeight = false;
 
     public IsochroneRequest setRegions(List<Region> regions) {
         this.regions = regions;
@@ -47,5 +48,14 @@ public class IsochroneRequest {
 
     public long getDistanceLimitInMeters() {
         return distanceLimitInMeters;
+    }
+
+    public IsochroneRequest setUseDistanceAsWeight(boolean useDistanceAsWeight) {
+        this.useDistanceAsWeight = useDistanceAsWeight;
+        return this;
+    }
+
+    public boolean getUseDistanceAsWeight() {
+        return useDistanceAsWeight;
     }
 }

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -161,10 +161,7 @@ public class IsochroneResource {
         }
         Collection<Coordinate> sites = new ArrayList<>();
         Collection<SegmentWithCost> segments = new ArrayList<>();
-        // When searching from several nodes we need to use the distance as weight in the Dijkstra,
-        // so that we are guaranteed to get a lower bound on the actual distance.
-        boolean useDistanceAsWeight = request.getRegions().size() > 1;
-        shortestPathTree.search(useDistanceAsWeight, fromNodes, label -> {
+        shortestPathTree.search(request.getUseDistanceAsWeight(), fromNodes, label -> {
             double exploreValue = fz.applyAsDouble(label);
             double lat = na.getLat(label.node);
             double lon = na.getLon(label.node);

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -161,7 +161,10 @@ public class IsochroneResource {
         }
         Collection<Coordinate> sites = new ArrayList<>();
         Collection<SegmentWithCost> segments = new ArrayList<>();
-        shortestPathTree.search(fromNodes, label -> {
+        // When searching from several nodes we need to use the distance as weight in the Dijkstra,
+        // so that we are guaranteed to get a lower bound on the actual distance.
+        boolean useDistanceAsWeight = request.getRegions().size() > 1;
+        shortestPathTree.search(useDistanceAsWeight, fromNodes, label -> {
             double exploreValue = fz.applyAsDouble(label);
             double lat = na.getLat(label.node);
             double lon = na.getLon(label.node);

--- a/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/SPTResource.java
@@ -143,7 +143,7 @@ public class SPTResource {
                 }
                 sb.append(LINE_SEP);
                 writer.write(sb.toString());
-                shortestPathTree.search(new ArrayList(snap.getClosestNode()), l -> {
+                shortestPathTree.search(false, new ArrayList(snap.getClosestNode()), l -> {
                     IsoLabelWithCoordinates label = isoLabelWithCoordinates(nodeAccess, l);
                     sb.setLength(0);
                     for (int colIndex = 0; colIndex < columns.size(); colIndex++) {


### PR DESCRIPTION
This PR fixes a bug where the distance lower bounds computed for groups of nodes weren't actually valid for each node individually.

The distance for a node `u` could be smaller than the distance lower bound for the group if there was another node `v` in the group with a smaller weight path to the destination, but a greater actual distance. In such a case `v`'s path would be used as the lower bound, but this PR changes this so that instead we use the path with the minimum actual distance.