### PR TITLE
Fix Graphhopper costs sometimes being inaccurate

### DIFF
--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
@@ -34,6 +34,9 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.function.Consumer;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import static com.graphhopper.isochrone.algorithm.ShortestPathTree.ExploreType.*;
 import static java.util.Comparator.comparingDouble;
 
@@ -53,6 +56,8 @@ import static java.util.Comparator.comparingDouble;
 public class ShortestPathTree extends AbstractRoutingAlgorithm {
 
     enum ExploreType {TIME, DISTANCE, WEIGHT}
+
+    private static final Logger logger = LoggerFactory.getLogger(ShortestPathTree.class);
 
     public static class IsoLabel {
 
@@ -167,6 +172,20 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
                     continue;
 
                 double nextDistance = iter.getDistance() + currentLabel.distance;
+                if (Math.abs(currentLabel.distance-119.219604) < 1e-5) { // && Math.abs(nextDistance-168.41527) < 1e-5) {
+                    logger.error("\n\n\nFound the bad edge");
+                    logger.error("distance = " + Double.toString(iter.getDistance()));
+                    IsoLabel node = currentLabel.parent;
+                    while (node != null) {
+                        double lat = this.graph.getNodeAccess().getLat(node.node);
+                        double lon = this.graph.getNodeAccess().getLon(node.node);
+                        logger.error("\n(" + Double.toString(lat) + ", " + Double.toString(lon) + ")");
+                        logger.error("distance = " + Double.toString(node.distance));
+                        logger.error("weight = " + Double.toString(node.weight));
+                        node = node.parent;
+                    }
+                    logger.error("\n\n\n");
+                }
                 if (useDistanceAsWeight) {
                     nextWeight = nextDistance;
                 }

--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
@@ -34,9 +34,6 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.function.Consumer;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import static com.graphhopper.isochrone.algorithm.ShortestPathTree.ExploreType.*;
 import static java.util.Comparator.comparingDouble;
 
@@ -56,8 +53,6 @@ import static java.util.Comparator.comparingDouble;
 public class ShortestPathTree extends AbstractRoutingAlgorithm {
 
     enum ExploreType {TIME, DISTANCE, WEIGHT}
-
-    private static final Logger logger = LoggerFactory.getLogger(ShortestPathTree.class);
 
     public static class IsoLabel {
 
@@ -172,20 +167,6 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
                     continue;
 
                 double nextDistance = iter.getDistance() + currentLabel.distance;
-                if (Math.abs(currentLabel.distance-119.219604) < 1e-5) { // && Math.abs(nextDistance-168.41527) < 1e-5) {
-                    logger.error("\n\n\nFound the bad edge");
-                    logger.error("distance = " + Double.toString(iter.getDistance()));
-                    IsoLabel node = currentLabel.parent;
-                    while (node != null) {
-                        double lat = this.graph.getNodeAccess().getLat(node.node);
-                        double lon = this.graph.getNodeAccess().getLon(node.node);
-                        logger.error("\n(" + Double.toString(lat) + ", " + Double.toString(lon) + ")");
-                        logger.error("distance = " + Double.toString(node.distance));
-                        logger.error("weight = " + Double.toString(node.weight));
-                        node = node.parent;
-                    }
-                    logger.error("\n\n\n");
-                }
                 if (useDistanceAsWeight) {
                     nextWeight = nextDistance;
                 }

--- a/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
+++ b/core/src/main/java/com/graphhopper/isochrone/algorithm/ShortestPathTree.java
@@ -56,7 +56,7 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
 
     public static class IsoLabel {
 
-        IsoLabel(int node, int edge, double weight, long time, double distance, IsoLabel parent) {
+        public IsoLabel(int node, int edge, double weight, long time, double distance, IsoLabel parent) {
             this.node = node;
             this.edge = edge;
             this.weight = weight;
@@ -132,12 +132,20 @@ public class ShortestPathTree extends AbstractRoutingAlgorithm {
     }
 
     public void search(boolean useDistanceAsWeight, List<Integer> from, final Consumer<IsoLabel> consumer) {
-        checkAlreadyRun();
+        List<IsoLabel> fromLabels = new ArrayList<>();
         for (int node : from) {
             IsoLabel currentLabel = new IsoLabel(node, -1, 0, 0, 0, null);
+            fromLabels.add(currentLabel);
+        }
+        searchFromLabels(useDistanceAsWeight, fromLabels, consumer);
+    }
+
+    public void searchFromLabels(boolean useDistanceAsWeight, List<IsoLabel> from, final Consumer<IsoLabel> consumer) {
+        checkAlreadyRun();
+        for (IsoLabel currentLabel : from) {
             queueByWeighting.add(currentLabel);
             if (traversalMode == TraversalMode.NODE_BASED) {
-                fromMap.put(node, currentLabel);
+                fromMap.put(currentLabel.node, currentLabel);
                 consumer.accept(currentLabel);
             }
         }

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -8,6 +8,7 @@ import com.graphhopper.http.ProfileResolver;
 import com.graphhopper.storage.NodeAccess;
 import com.graphhopper.isochrone.algorithm.ShortestPathTree;
 import com.graphhopper.isochrone.algorithm.Triangulator;
+import com.graphhopper.isochrone.algorithm.ShortestPathTree.IsoLabel;
 import com.graphhopper.routing.ev.BooleanEncodedValue;
 import com.graphhopper.routing.ev.Subnetwork;
 import com.graphhopper.routing.querygraph.QueryGraph;
@@ -194,13 +195,16 @@ public class IsochroneResource {
         zs.add(limit);
 
         final NodeAccess na = queryGraph.getNodeAccess();
-        List<Integer> fromNodes = new ArrayList<Integer>();
+        List<IsoLabel> fromLabels = new ArrayList<IsoLabel>();
         for (Snap snap : snaps) {
-            fromNodes.add(snap.getClosestNode());
+            int node = snap.getClosestNode();
+            // TODO: Set the weight and the time to reasonable values, if needed.
+            IsoLabel currentLabel = new IsoLabel(node, -1, 0, 0, snap.getQueryDistance(), null);
+            fromLabels.add(currentLabel);
         }
         Collection<Coordinate> sites = new ArrayList<>();
         Collection<SegmentWithCost> segments = new ArrayList<>();
-        shortestPathTree.search(request.getUseDistanceAsWeight(), fromNodes, label -> {
+        shortestPathTree.searchFromLabels(request.getUseDistanceAsWeight(), fromLabels, label -> {
             double exploreValue = fz.applyAsDouble(label);
             double lat = na.getLat(label.node);
             double lon = na.getLon(label.node);

--- a/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
+++ b/web-bundle/src/main/java/com/graphhopper/resources/IsochroneResource.java
@@ -111,8 +111,8 @@ public class IsochroneResource {
     @Consumes(MediaType.APPLICATION_JSON)
     @Produces(MediaType.APPLICATION_JSON)
     public ResponseWithCosts doPost(@NotNull IsochroneRequest request) {
-        DistanceCalcEarth distanceCalculator = new DistanceCalcEarth();
         StopWatch sw = new StopWatch().start();
+        DistanceCalcEarth distanceCalculator = new DistanceCalcEarth();
         PMap hintsMap = new PMap();
         hintsMap.putObject(Parameters.CH.DISABLE, true);
         hintsMap.putObject(Parameters.Landmark.DISABLE, true);


### PR DESCRIPTION
This PR fixes two issues with the Graphhopper costs by:
* accounting for the distance associated with snapping from the search origin (a point or a polygon, e.g. a school) to the graph.
* improving the accuracy of costs of pillar (interior) nodes on paths by taking the actual distances of the path's subsegments into account.